### PR TITLE
Added suggester for fmt and lint

### DIFF
--- a/.github/workflows/suggest.yaml
+++ b/.github/workflows/suggest.yaml
@@ -1,0 +1,24 @@
+name: Suggest
+
+on: [pull_request]
+
+permissions:
+  contents: read
+  checks: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  deno:
+    name: Deno Suggester
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - run: deno fmt
+      - run: deno lint --fix
+      - uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: deno

--- a/deno.lock
+++ b/deno.lock
@@ -10,6 +10,7 @@
     "jsr:@effection/effection@3.1.0": "3.1.0",
     "jsr:@frontside/continuation@0.1.6": "0.1.6",
     "jsr:@libs/xml@*": "6.0.4",
+    "jsr:@std/assert@*": "1.0.10",
     "jsr:@std/assert@1.0.10": "1.0.10",
     "jsr:@std/bytes@^1.0.2": "1.0.4",
     "jsr:@std/cache@0.1.3": "0.1.3",
@@ -97,7 +98,7 @@
       "integrity": "3891a1ad37df3b85f03bce582c61f47904576a001b31163af29ba79c3b677f5f",
       "dependencies": [
         "jsr:@frontside/continuation",
-        "jsr:@std/assert"
+        "jsr:@std/assert@1.0.10"
       ]
     },
     "@frontside/continuation@0.1.6": {


### PR DESCRIPTION
## Motivation

I find fixing lint and fmt errors after they fail in CI.

## Approach

Add [suggester](https://github.com/reviewdog/action-suggester/tree/v1/?tab=readme-ov-file#action-suggester) workflow that will automatically suggest fmt and lint fixes.