### PR TITLE
Using effection to prevent component header from closing unnecessarily

### DIFF
--- a/assets/search.js
+++ b/assets/search.js
@@ -1,20 +1,107 @@
-document.addEventListener("DOMContentLoaded", function () {
-  const searchElement = document.getElementById("search");
-  if (searchElement) {
-    searchElement.addEventListener("blur", function () {
-      searchElement.value = "";
-      searchElement.setAttribute("placeholder", "⌘K");
-    });
+import {
+  main,
+  on,
+  each,
+  spawn,
+  suspend,
+  resource,
+  createChannel,
+  sleep,
+} from "https://esm.sh/effection@4.0.0-alpha.5";
 
-    document.addEventListener("keydown", function (event) {
-      if (event.metaKey && event.key === "k") {
-        event.preventDefault();
-        searchElement.focus();
-        searchElement.removeAttribute("placeholder");
-      }
-      if (event.key === "Escape") {
-        searchElement.blur();
-      }
-    });
+await main(function* () {
+  const input = document.getElementById("search");
+  if (!input) {
+    console.log(`Search could not be setup because input was not found.`);
+    return;
   }
+
+  const label = input.closest("label");
+  if (!label) {
+    console.log(
+      `Search could not be setup because label element was not found.`,
+    );
+    return;
+  }
+
+  const button = input.nextElementSibling;
+  if (!button) {
+    console.log(
+      `Search could not be setup because button element was not found.`,
+    );
+    return;
+  }
+
+  let lastBlur;
+  yield* forEach(
+    yield* join([
+      on(input, "focus"),
+      on(button, "focus"),
+      on(input, "blur"),
+      on(button, "blur"),
+    ]),
+    function* (event) {
+      if (event.type === "blur") {
+        lastBlur = yield* spawn(function* () {
+          yield* sleep(15);
+          input.value = "";
+          input.setAttribute("placeholder", "⌘K");
+          input.classList.remove("focused");
+        });
+      } else {
+        if (lastBlur) {
+          yield* lastBlur.halt();
+        }
+        input.removeAttribute("placeholder");
+        input.classList.add("focused");
+      }
+    },
+  );
+
+  yield* forEach(on(document, "keydown"), function* (event) {
+    if (event.metaKey && event.key === "k") {
+      event.preventDefault();
+      input.focus();
+    }
+    if (event.key === "Escape") {
+      input.blur();
+    }
+  });
+
+  yield* suspend();
 });
+
+/**
+ * @param {Stream<Event, void>} stream
+ * @param {(event: Event) => Operation<void>} op
+ * @returns
+ */
+function forEach(stream, op) {
+  return spawn(function* () {
+    for (const event of yield* each(stream)) {
+      yield* op(event);
+      yield* each.next();
+    }
+    yield* suspend();
+  });
+}
+
+/**
+ * @template {T}
+ * @param {Stream<T>[]} streams
+ * @returns {Operation<Stream<T>>}
+ */
+function join(streams) {
+  return resource(function* (provide) {
+    const channel = createChannel();
+    yield* spawn(function* () {
+      for (const stream of streams) {
+        yield* forEach(stream, function* (event) {
+          yield* channel.send(event);
+        });
+      }
+      yield* suspend();
+    });
+    yield* provide(channel);
+  });
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -18,13 +18,15 @@ const colorful = css`
 `;
 
 const searchInput = css`
-  @apply relative block h-full w-full bg-slate-100 rounded-full text-slate-800 transition-all text-lg pl-3;
+  input {
+    @apply relative block h-full w-full bg-slate-100 rounded-full text-slate-800 transition-all text-lg pl-3;
+  }
 
-  &:focus {
+  input.focused {
     @apply outline-none bg-white border-slate-500 ring-slate-500 ring-2 pl-4 w-[220px] -ml-[130px] z-1;
   }
 
-  &::-webkit-search-cancel-button {
+  input::-webkit-search-cancel-button {
     -webkit-appearance: none;
     appearance: none;
   }
@@ -92,29 +94,25 @@ export function* Header(props?: HeaderProps) {
                   <span>Discord</span>
                 </a>
               </li>
-              {props?.hasLeftSidebar
-                ? (
-                  <li class="flex flex-row md:hidden">
-                    <label class="cursor-pointer" for="nav-toggle">
-                      <Navburger />
-                    </label>
-                  </li>
-                )
-                : <></>}
-              <li class="hidden md:flex">
+              {props?.hasLeftSidebar ? (
+                <li class="flex flex-row md:hidden">
+                  <label class="cursor-pointer" for="nav-toggle">
+                    <Navburger />
+                  </label>
+                </li>
+              ) : (
+                <></>
+              )}
+              <li class={`${searchInput} hidden md:flex`}>
                 <form method="get" action="/search">
                   <label class="h-9 w-[90px] relative block">
                     <input
                       id="search"
                       type="search"
                       name="q"
-                      class={searchInput}
                       placeholder="⌘K"
                     />
-                    <button
-                      class="absolute inset-y-0 right-0 flex items-center pr-2"
-                      tabindex={-1}
-                    >
+                    <button class="absolute inset-y-0 right-0 flex items-center pr-2">
                       <SearchIcon class="w-6 mr-2 text-slate-400" />
                     </button>
                   </label>

--- a/deno.lock
+++ b/deno.lock
@@ -1966,6 +1966,9 @@
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     }
   },
+  "redirects": {
+    "https://esm.sh/effection@4.0.0.alpha.5": "https://esm.sh/effection@3.2.0"
+  },
   "remote": {
     "https://deno.land/std@0.140.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
     "https://deno.land/std@0.140.0/_util/os.ts": "3b4c6e27febd119d36a416d7a97bd3b0251b77c88942c8f16ee5953ea13e2e49",
@@ -2205,7 +2208,11 @@
     "https://deno.land/x/revolution@0.6.0/lib/server.ts": "560765955e3d6129f8f5d9fcaf4f598ddb0b9543db766f7a1a8d18d360b0a07c",
     "https://deno.land/x/revolution@0.6.0/lib/sse.ts": "3ace8fd4b2935e264940511366513bfeb5b414e457bc3d6a916d123b20a80d3c",
     "https://deno.land/x/revolution@0.6.0/lib/types.ts": "2f32cbc673d496b5a37e5b9ff829577866d66a19b993ed59840b92700861d237",
-    "https://deno.land/x/revolution@0.6.0/mod.ts": "ffae461c16d4a1bf24c2179582ab8d5c81ad0df61e4ae2fba51ef5e5bdf90345"
+    "https://deno.land/x/revolution@0.6.0/mod.ts": "ffae461c16d4a1bf24c2179582ab8d5c81ad0df61e4ae2fba51ef5e5bdf90345",
+    "https://esm.sh/effection@3.2.0": "2ddb773aebe996113bb54a0ee1dc4e6bf4120e746154d4f1d0bbd5f8a23f8577",
+    "https://esm.sh/effection@3.2.0/denonext/effection.mjs": "7ad88b07df5ff6c997a95c95dcf5c569e3a2b651796b9757f91aae3aaf73a532",
+    "https://esm.sh/effection@4.0.0-alpha.5": "1ceb25592760186e79e769cd9a3026f450a87f5c5b8b1af38f9719af740f7fcd",
+    "https://esm.sh/effection@4.0.0-alpha.5/denonext/effection.mjs": "8384de42269aebc28c1f0008ca690126eed82b0c4d20b7f9f8fa765cf53444c8"
   },
   "workspace": {
     "dependencies": [


### PR DESCRIPTION
## Motivation

I want to improve search to give priority to content for stable release. I believe the priority should be,

1. 3x docs
2. 2x API ref
3. contribs
4. 4x docs
5. 4x API ref

^^ I didn't do this yet, but I did make search field smarter using effection.

![2025-01-25 22 11 33](https://github.com/user-attachments/assets/ed08b403-5fa9-4c6a-9b72-3dc0251b726c)


## Approach

<!-- REQUIRED
  How does this change fulfill the purpose? Keep it high level. Avoid code-splaining.
-->

### Alternate Designs

 <!-- OPTIONAL
   Explain what other alternatives you considered and why you chose this option.
 -->

### Possible Drawbacks or Risks

 <!-- OPTIONAL
   What are the possible side-effects or negative impacts of this change?
 -->

### TODOs and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the conclusion.
-->

## Learning

<!-- OPTIONAL
  Share any blog posts, patterns, libraries, or documentation that helped you.
-->

## Screenshots

<!-- OPTIONAL
  If relevant, include "before" and "after" to demonstrate this change. Add a caption describing what each screenshot shows.
-->
