### PR TITLE
Reading docs from docs instead of www/docs

### DIFF
--- a/lib/toc.ts
+++ b/lib/toc.ts
@@ -4,11 +4,10 @@ import { customizationHooks } from "npm:@jsdevtools/rehype-toc@3.0.2/lib/customi
 import { findHeadings } from "npm:@jsdevtools/rehype-toc@3.0.2/lib/fiind-headings.js";
 import { findMainNode } from "npm:@jsdevtools/rehype-toc@3.0.2/lib/find-main-node.js";
 import { NormalizedOptions } from "npm:@jsdevtools/rehype-toc@3.0.2/lib/options.js";
-import type hast from "npm:@types/hast@3.0.4";
+import type { Nodes } from "npm:@types/hast@3.0.4";
+import { JSXElement } from "revolution/jsx-runtime";
 
-export type Nodes = hast.Nodes;
-
-export function toc(root: Nodes, options?: Options) {
+export function toc(root: Nodes, options?: Options): JSXElement {
   const _options = new NormalizedOptions(
     options ?? {
       cssClasses: {

--- a/resources/docs.ts
+++ b/resources/docs.ts
@@ -70,7 +70,7 @@ export function loadDocs(
 
       const ref = yield* repo.loadRef(`tags/${latest.name}`);
 
-      const json = yield* ref.loadJson("www/docs/structure.json");
+      const json = yield* ref.loadJson("docs/structure.json");
 
       const structure = Structure.parse(json);
 
@@ -90,7 +90,7 @@ export function loadDocs(
           let meta: DocMeta = current = {
             id: basename(filename, ".mdx"),
             title,
-            filename: `www/docs/${filename}`,
+            filename: `docs/${filename}`,
             topics,
             prev,
           };


### PR DESCRIPTION
## Motivation

https://github.com/thefrontside/effection/pull/969 and https://github.com/thefrontside/effection/pull/967 removed `www` from the effection repository.

## Approach

Change the path of the docs directory to align with upstream changes.
