### PR TITLE
Added TOC to contrib page

### DIFF
--- a/components/api/api-page.tsx
+++ b/components/api/api-page.tsx
@@ -53,21 +53,23 @@ export function* ApiPage({
 
   return (
     <>
-      {yield* ApiReference({
-        pages,
-        current,
-        ref,
-        content: (
-          <>
-            <>{banner}</>
-            {yield* SymbolHeader({ pkg, page })}
-            {yield* ApiBody({ page, linkResolver })}
-          </>
-        ),
-        linkResolver: function* (symbol) {
-          return yield* createSibling(symbol);
-        },
-      })}
+      {
+        yield* ApiReference({
+          pages,
+          current,
+          ref,
+          content: (
+            <>
+              <>{banner}</>
+              {yield* SymbolHeader({ pkg, page })}
+              {yield* ApiBody({ page, linkResolver })}
+            </>
+          ),
+          linkResolver: function* (symbol) {
+            return yield* createSibling(symbol);
+          },
+        })
+      }
     </>
   );
 }
@@ -84,12 +86,16 @@ export function* ApiBody({
   for (const [i, section] of Object.entries(page.sections)) {
     if (section.markdown) {
       elements.push(
-        <section
-          id={section.id}
-          class={`${i !== "0" ? "border-t-2" : ""} pb-7`}
-        >
+        <section class={`${i !== "0" ? "border-t-2" : ""} pb-7`}>
           <div class="flex mt-7 group">
-            <h2 class="my-0 grow">{yield* Type({ node: section.node })}</h2>
+            <h2
+              class="my-0 grow"
+              id={section.id}
+              data-kind={section.node.kind}
+              data-name={section.node.name}
+            >
+              {yield* Type({ node: section.node })}
+            </h2>
             <a
               class="opacity-0 before:content-['View_code'] group-hover:opacity-100 before:flex before:text-xs before:mr-1 hover:bg-gray-100 p-2 flex-none flex rounded no-underline items-center h-8"
               href={`${section.node.location.filename}#L${section.node.location.line}`}
@@ -98,10 +104,12 @@ export function* ApiBody({
             </a>
           </div>
           <div class="[&>hr]:my-5 [&>p]:mb-0">
-            {yield* useMarkdown(section.markdown, {
-              linkResolver,
-              slugPrefix: section.id,
-            })}
+            {
+              yield* useMarkdown(section.markdown, {
+                linkResolver,
+                slugPrefix: section.id,
+              })
+            }
           </div>
         </section>,
       );
@@ -124,9 +132,8 @@ export function* ApiReference({
   pages: DocPage[];
   linkResolver: ResolveLinkFunction;
 }) {
-  const version = extractVersion(ref.name) === "0.0.0"
-    ? ref.name
-    : extractVersion(ref.name);
+  const version =
+    extractVersion(ref.name) === "0.0.0" ? ref.name : extractVersion(ref.name);
 
   return (
     <section class="min-h-0 mx-auto w-full justify-items-normal md:grid md:grid-cols-[225px_auto] lg:grid-cols-[225px_auto_200px] md:gap-4">
@@ -168,10 +175,12 @@ export function* SymbolHeader({ page, pkg }: { page: DocPage; pkg: Package }) {
         </Keyword>{" "}
         {page.name}
       </h1>
-      {yield* GithubPill({
-        url: pkg.source.toString(),
-        text: pkg.ref.repository.nameWithOwner,
-      })}
+      {
+        yield* GithubPill({
+          url: pkg.source.toString(),
+          text: pkg.ref.repository.nameWithOwner,
+        })
+      }
     </header>
   );
 }
@@ -189,22 +198,20 @@ function* Menu({
   for (const page of pages.sort((a, b) => a.name.localeCompare(b.name))) {
     elements.push(
       <li>
-        {current === page.name
-          ? (
-            <span class="rounded px-2 block w-full py-2 bg-gray-100 cursor-default ">
-              <Icon kind={page.kind} />
-              {page.name}
-            </span>
-          )
-          : (
-            <a
-              class="rounded px-2 block w-full py-2 hover:bg-gray-100"
-              href={yield* linkResolver(page.name)}
-            >
-              <Icon kind={page.kind} />
-              {page.name}
-            </a>
-          )}
+        {current === page.name ? (
+          <span class="rounded px-2 block w-full py-2 bg-gray-100 cursor-default ">
+            <Icon kind={page.kind} />
+            {page.name}
+          </span>
+        ) : (
+          <a
+            class="rounded px-2 block w-full py-2 hover:bg-gray-100"
+            href={yield* linkResolver(page.name)}
+          >
+            <Icon kind={page.kind} />
+            {page.name}
+          </a>
+        )}
       </li>,
     );
   }

--- a/components/api/api-page.tsx
+++ b/components/api/api-page.tsx
@@ -53,23 +53,21 @@ export function* ApiPage({
 
   return (
     <>
-      {
-        yield* ApiReference({
-          pages,
-          current,
-          ref,
-          content: (
-            <>
-              <>{banner}</>
-              {yield* SymbolHeader({ pkg, page })}
-              {yield* ApiBody({ page, linkResolver })}
-            </>
-          ),
-          linkResolver: function* (symbol) {
-            return yield* createSibling(symbol);
-          },
-        })
-      }
+      {yield* ApiReference({
+        pages,
+        current,
+        ref,
+        content: (
+          <>
+            <>{banner}</>
+            {yield* SymbolHeader({ pkg, page })}
+            {yield* ApiBody({ page, linkResolver })}
+          </>
+        ),
+        linkResolver: function* (symbol) {
+          return yield* createSibling(symbol);
+        },
+      })}
     </>
   );
 }
@@ -104,12 +102,10 @@ export function* ApiBody({
             </a>
           </div>
           <div class="[&>hr]:my-5 [&>p]:mb-0">
-            {
-              yield* useMarkdown(section.markdown, {
-                linkResolver,
-                slugPrefix: section.id,
-              })
-            }
+            {yield* useMarkdown(section.markdown, {
+              linkResolver,
+              slugPrefix: section.id,
+            })}
           </div>
         </section>,
       );
@@ -132,8 +128,9 @@ export function* ApiReference({
   pages: DocPage[];
   linkResolver: ResolveLinkFunction;
 }) {
-  const version =
-    extractVersion(ref.name) === "0.0.0" ? ref.name : extractVersion(ref.name);
+  const version = extractVersion(ref.name) === "0.0.0"
+    ? ref.name
+    : extractVersion(ref.name);
 
   return (
     <section class="min-h-0 mx-auto w-full justify-items-normal md:grid md:grid-cols-[225px_auto] lg:grid-cols-[225px_auto_200px] md:gap-4">
@@ -175,12 +172,10 @@ export function* SymbolHeader({ page, pkg }: { page: DocPage; pkg: Package }) {
         </Keyword>{" "}
         {page.name}
       </h1>
-      {
-        yield* GithubPill({
-          url: pkg.source.toString(),
-          text: pkg.ref.repository.nameWithOwner,
-        })
-      }
+      {yield* GithubPill({
+        url: pkg.source.toString(),
+        text: pkg.ref.repository.nameWithOwner,
+      })}
     </header>
   );
 }
@@ -198,20 +193,22 @@ function* Menu({
   for (const page of pages.sort((a, b) => a.name.localeCompare(b.name))) {
     elements.push(
       <li>
-        {current === page.name ? (
-          <span class="rounded px-2 block w-full py-2 bg-gray-100 cursor-default ">
-            <Icon kind={page.kind} />
-            {page.name}
-          </span>
-        ) : (
-          <a
-            class="rounded px-2 block w-full py-2 hover:bg-gray-100"
-            href={yield* linkResolver(page.name)}
-          >
-            <Icon kind={page.kind} />
-            {page.name}
-          </a>
-        )}
+        {current === page.name
+          ? (
+            <span class="rounded px-2 block w-full py-2 bg-gray-100 cursor-default ">
+              <Icon kind={page.kind} />
+              {page.name}
+            </span>
+          )
+          : (
+            <a
+              class="rounded px-2 block w-full py-2 hover:bg-gray-100"
+              href={yield* linkResolver(page.name)}
+            >
+              <Icon kind={page.kind} />
+              {page.name}
+            </a>
+          )}
       </li>,
     );
   }

--- a/components/package/header.tsx
+++ b/components/package/header.tsx
@@ -4,17 +4,22 @@ import { GithubPill } from "./source-link.tsx";
 export function* PackageHeader(pkg: Package) {
   return (
     <header class="space-y-3 mb-5">
-      <div class="flex flex-row">
-        <span class="text-3xl font-bold">
-          @{pkg.scope}
-          <span>/</span>
-          {pkg.name}
+      <div class="flex flex-col xl:flex-row">
+        <span class="text-3xl">
+          <span class="font-bold">
+            @{pkg.scope}
+            <span>/</span>
+            {pkg.name}
+          </span>
+          <span class="mx-2">v{pkg.version ? pkg.version : ""}</span>
         </span>
-        <span class="text-3xl mx-2">v{pkg.version ? pkg.version : ""}</span>
-        {yield* GithubPill({
-          url: pkg.source.toString(),
-          text: pkg.ref.repository.nameWithOwner,
-        })}
+        {
+          yield* GithubPill({
+            class: "mt-2 xl:mt-0",
+            url: pkg.source.toString(),
+            text: pkg.ref.repository.nameWithOwner,
+          })
+        }
       </div>
       <div class="space-x-1">
         <a href={`${pkg.jsr}`} class="inline-block align-middle">

--- a/components/package/header.tsx
+++ b/components/package/header.tsx
@@ -13,13 +13,11 @@ export function* PackageHeader(pkg: Package) {
           </span>
           <span class="mx-2">v{pkg.version ? pkg.version : ""}</span>
         </span>
-        {
-          yield* GithubPill({
-            class: "mt-2 xl:mt-0",
-            url: pkg.source.toString(),
-            text: pkg.ref.repository.nameWithOwner,
-          })
-        }
+        {yield* GithubPill({
+          class: "mt-2 xl:mt-0",
+          url: pkg.source.toString(),
+          text: pkg.ref.repository.nameWithOwner,
+        })}
       </div>
       <div class="space-x-1">
         <a href={`${pkg.jsr}`} class="inline-block align-middle">

--- a/components/package/source-link.tsx
+++ b/components/package/source-link.tsx
@@ -13,7 +13,7 @@ export function* GithubPill({
   return (
     <a
       href={url}
-      class={`flex flex-row h-10 items-center rounded-full bg-gray-200 px-2 py-1 ${
+      class={`flex flex-row w-fit h-10 items-center rounded-full bg-gray-200 px-2 py-1 ${
         props.class ?? ""
       }`}
     >

--- a/components/score-card.tsx
+++ b/components/score-card.tsx
@@ -22,7 +22,7 @@ export function* ScoreCard(pkg: Package) {
   return (
     <div class="flex flex-col w-full space-y-5 sm:items-end lg:space-y-5">
       <div class="grid grid-cols-4 lg:grid-cols-2">
-        <div class="text-sm font-bold">
+        <div class="text-sm font-bold md:mb-3">
           <div aria-hidden="true">Published on</div>
           <div class="space-x-2 pt-1">
             <a class="inline-block" href={`${pkg.jsr}`}>
@@ -33,7 +33,7 @@ export function* ScoreCard(pkg: Package) {
             </a>
           </div>
         </div>
-        <div class="text-sm font-bold md:ml-5">
+        <div class="text-sm font-bold md:ml-5 md:mb-3">
           <div>TypeScript</div>
           <span class="text-green-600 text-lg">Yes</span>
         </div>

--- a/components/score-card.tsx
+++ b/components/score-card.tsx
@@ -20,88 +20,84 @@ export function* ScoreCard(pkg: Package) {
   const jsrScore = (details.success && details.data && details.data.score) || 0;
 
   return (
-    <div class="flex flex-col items-center space-y-5 w-full">
-      <>
-        <div class="flex flex-col md:flex-row gap-2 md:gap-8 items-between">
-          <div class="flex flex-row md:flex-col items-center md:items-end gap-2 md:gap-1.5 text-sm font-bold">
-            <div aria-hidden="true">Published on</div>
-            <div class="flex space-x-2">
-              <a href={`${pkg.jsr}`}>
-                <JSRIcon class="h-6" />
-              </a>
-              <a href={`${pkg.npm}`}>
-                <NPMIcon class="h-6" />
-              </a>
-            </div>
-          </div>
-          <div class="flex flex-row md:flex-col items-baseline md:items-end gap-2 md:gap-1.5 text-sm font-bold">
-            <div>TypeScript</div>
-            <span class="text-green-600 text-lg">Yes</span>
+    <div class="flex flex-col w-full space-y-5 sm:items-end lg:space-y-5">
+      <div class="grid grid-cols-4 lg:grid-cols-2">
+        <div class="text-sm font-bold">
+          <div aria-hidden="true">Published on</div>
+          <div class="space-x-2 pt-1">
+            <a class="inline-block" href={`${pkg.jsr}`}>
+              <JSRIcon class="h-6" />
+            </a>
+            <a class="inline-block" href={`${pkg.npm}`}>
+              <NPMIcon class="h-6" />
+            </a>
           </div>
         </div>
-        <div class="flex flex-col md:flex-row gap-2 md:gap-8 items-between">
-          <div class="flex flex-row md:flex-col items-center md:items-end gap-2 md:gap-1.5 text-sm font-bold">
-            <div aria-hidden="true">Works with</div>
-            <div class="min-w-content font-semibold select-none">
-              <div class="flex items-center *:mx-0.5 flex-row-reverse">
-                <SupportedEnvironment
-                  name="Cloudflare Workers"
-                  Icon={CloudflareWorkersIcon}
-                  width={416}
-                  height={375}
-                  enabled={details.data?.runtimeCompat.workerd ?? false}
-                />
-                <SupportedEnvironment
-                  name="Node.js"
-                  Icon={NodeIcon}
-                  width={256}
-                  height={292}
-                  enabled={details.data?.runtimeCompat.node ?? false}
-                />
-                <SupportedEnvironment
-                  name="Deno"
-                  Icon={DenoIcon}
-                  width={512}
-                  height={512}
-                  enabled={details.data?.runtimeCompat.deno ?? false}
-                />
-                <SupportedEnvironment
-                  name="Bun"
-                  Icon={BunIcon}
-                  width={435}
-                  height={435}
-                  enabled={details.data?.runtimeCompat.bun ?? false}
-                />
-                <SupportedEnvironment
-                  name="Browser"
-                  Icon={BrowserIcon}
-                  width={1200}
-                  height={500}
-                  enabled={details.data?.runtimeCompat.browser ?? false}
-                />
-              </div>
+        <div class="text-sm font-bold md:ml-5">
+          <div>TypeScript</div>
+          <span class="text-green-600 text-lg">Yes</span>
+        </div>
+        <div class="text-sm font-bold">
+          <div class="pb-1" aria-hidden="true">Works with</div>
+          <div class="min-w-content font-semibold select-none">
+            <div class="flex *:mx-0.5">
+              <SupportedEnvironment
+                name="Cloudflare Workers"
+                Icon={CloudflareWorkersIcon}
+                width={416}
+                height={375}
+                enabled={details.data?.runtimeCompat.workerd ?? false}
+              />
+              <SupportedEnvironment
+                name="Node.js"
+                Icon={NodeIcon}
+                width={256}
+                height={292}
+                enabled={details.data?.runtimeCompat.node ?? false}
+              />
+              <SupportedEnvironment
+                name="Deno"
+                Icon={DenoIcon}
+                width={512}
+                height={512}
+                enabled={details.data?.runtimeCompat.deno ?? false}
+              />
+              <SupportedEnvironment
+                name="Bun"
+                Icon={BunIcon}
+                width={435}
+                height={435}
+                enabled={details.data?.runtimeCompat.bun ?? false}
+              />
+              <SupportedEnvironment
+                name="Browser"
+                Icon={BrowserIcon}
+                width={1200}
+                height={500}
+                enabled={details.data?.runtimeCompat.browser ?? false}
+              />
             </div>
           </div>
-          <a
-            class="flex flex-row md:flex-col items-baseline md:items-end gap-2 md:gap-1.5 text-sm font-bold"
-            href={`${new URL("./score/", pkg.jsr)}`}
+        </div>
+        <a
+          class="text-sm font-bold md:ml-5"
+          href={`${new URL("./score/", pkg.jsr)}`}
+        >
+          <div class="pb-1">JSR Score</div>
+          <div
+            class={`!leading-none md:text-xl ${
+              getScoreTextColorClass(
+                jsrScore,
+              )
+            }`}
           >
-            <div>JSR Score</div>
-            <div
-              class={`!leading-none md:text-xl ${
-                getScoreTextColorClass(
-                  jsrScore,
-                )
-              }`}
-            >
-              {jsrScore}%
-            </div>
-          </a>
-        </div>
-        {score.success && score.data
-          ? <ScoreDescription score={score.data} pkg={pkg} />
-          : <></>}
-      </>
+            {jsrScore}%
+          </div>
+        </a>
+      </div>
+      {score.success && score.data
+        ? <ScoreDescription score={score.data} pkg={pkg} />
+        : <></>}
     </div>
   );
 }

--- a/components/type/icon.tsx
+++ b/components/type/icon.tsx
@@ -5,7 +5,7 @@ export function Icon(props: { kind: string; class?: string }) {
         <span
           class={`${
             props.class ? props.class : ""
-          } rounded-full bg-sky-100 inline-block w-6 h-full mr-1 text-center`}
+          } rounded-full bg-sky-100 inline-block w-6 h-6 mr-1 text-center`}
         >
           f
         </span>
@@ -15,7 +15,7 @@ export function Icon(props: { kind: string; class?: string }) {
         <span
           class={`${
             props.class ? props.class : ""
-          } rounded-full bg-orange-50 text-orange-600 inline-block w-6 h-full mr-1 text-center`}
+          } rounded-full bg-orange-50 text-orange-600 inline-block w-6 h-6 mr-1 text-center`}
         >
           I
         </span>
@@ -25,7 +25,7 @@ export function Icon(props: { kind: string; class?: string }) {
         <span
           class={`${
             props.class ? props.class : ""
-          } rounded-full bg-red-50 text-red-600 inline-block w-6 h-full mr-1 text-center`}
+          } rounded-full bg-red-50 text-red-600 inline-block w-6 h-6 mr-1 text-center`}
         >
           T
         </span>
@@ -35,7 +35,7 @@ export function Icon(props: { kind: string; class?: string }) {
         <span
           class={`${
             props.class ? props.class : ""
-          } rounded-full bg-purple-200 text-violet-600 inline-block w-6 h-full mr-1 text-center`}
+          } rounded-full bg-purple-200 text-violet-600 inline-block w-6 h-6 mr-1 text-center`}
         >
           v
         </span>

--- a/deno.lock
+++ b/deno.lock
@@ -56,6 +56,7 @@
     "npm:effection@4.0.0-alpha.4": "4.0.0-alpha.4",
     "npm:hast-util-select@6.0.1": "6.0.1",
     "npm:hast-util-select@6.0.3": "6.0.3",
+    "npm:hast-util-shift-heading@4.0.0": "4.0.0",
     "npm:hast-util-to-html@9.0.0": "9.0.0",
     "npm:http-errors@2.0.0": "2.0.0",
     "npm:octokit@4.0.3": "4.0.3_@octokit+core@6.1.3",
@@ -882,6 +883,14 @@
         "space-separated-tokens@2.0.2",
         "unist-util-visit",
         "zwitch@2.0.4"
+      ]
+    },
+    "hast-util-shift-heading@4.0.0": {
+      "integrity": "sha512-1WzYRfcydfUIAn/N/QBDLlaG/JlXnE3Tx2ybuQFZKP4ZfM9v8FPJ/8i6pEaSoEtEI+FzjYmALlOJROkgRg3epg==",
+      "dependencies": [
+        "@types/hast@3.0.4",
+        "hast-util-heading-rank",
+        "unist-util-visit"
       ]
     },
     "hast-util-to-estree@3.1.1": {

--- a/lib/toc.ts
+++ b/lib/toc.ts
@@ -7,13 +7,12 @@ import { NormalizedOptions } from "npm:@jsdevtools/rehype-toc@3.0.2/lib/options.
 import type { Nodes } from "npm:@types/hast@3.0.4";
 import { JSXElement } from "revolution/jsx-runtime";
 
-export function toc(root: Nodes, options?: Options): JSXElement {
+export function createToc(root: Nodes, options?: Options): JSXElement {
   const _options = new NormalizedOptions(
     options ?? {
       cssClasses: {
         toc:
           "hidden text-sm font-light tracking-wide leading-loose lg:block relative pt-2",
-        list: "w-[200px]",
         link: "hover:underline hover:underline-offset-2",
       },
     },

--- a/resources/docs.ts
+++ b/resources/docs.ts
@@ -10,7 +10,7 @@ import { basename } from "jsr:@std/path@1.0.8";
 import { Repository } from "./repository.ts";
 import { z } from "npm:zod@3.23.8";
 import { useMarkdown } from "../hooks/use-markdown.tsx";
-import { toc } from "../lib/toc.ts";
+import { createToc } from "../lib/toc.ts";
 import { JSXElement } from "revolution/jsx-runtime";
 
 export interface DocModule {
@@ -110,7 +110,7 @@ export function loadDocs(
                 ...meta,
                 markdown: source,
                 content,
-                toc: toc(content),
+                toc: createToc(content),
               };
             }),
           );

--- a/resources/jsr-client.ts
+++ b/resources/jsr-client.ts
@@ -38,7 +38,7 @@ const PackageDetails = z.object({
     name: z.string(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
-  }),
+  }).nullable(),
   score: z.number().min(0).max(100),
 });
 

--- a/routes/contrib-package-route.tsx
+++ b/routes/contrib-package-route.tsx
@@ -182,7 +182,7 @@ export function contribPackageRoute({
                 <aside class="xl:w-[260px] lg:col-[span_3/_-1] top-[120px] lg:sticky lg:max-h-screen flex flex-col box-border gap-y-4">
                   {yield* ScoreCard(pkg)}
                   <div>
-                    <div aria-hidden="true" class="hidden mb-1 md:block text-sm font-bold">
+                    <div aria-hidden="true" class="hidden mb-1 lg:block text-sm font-bold">
                       On this page
                     </div>
                     {toc}

--- a/routes/contrib-package-route.tsx
+++ b/routes/contrib-package-route.tsx
@@ -1,7 +1,6 @@
 import { type JSXElement, useParams } from "revolution";
 import { call } from "effection";
 import { shiftHeading } from "npm:hast-util-shift-heading@4.0.0";
-import rehypeAddClasses from "npm:rehype-add-classes@1.0.0";
 import type { Nodes } from "npm:@types/hast@3.0.4";
 
 import { PackageExports } from "../components/package/exports.tsx";
@@ -88,9 +87,11 @@ export function contribPackageRoute({
                 (page) => page.name === symbol,
               );
               if (page) {
-                return `[${symbol}](/api/${major(effection.version)}.${minor(
-                  effection.version,
-                )}/${symbol})`;
+                return `[${symbol}](/api/${major(effection.version)}.${
+                  minor(
+                    effection.version,
+                  )
+                }/${symbol})`;
               }
             }
           }
@@ -122,7 +123,8 @@ export function contribPackageRoute({
         const toc = createToc(content, {
           headings: ["h2", "h3"],
           cssClasses: {
-            toc: "hidden text-sm font-light tracking-wide leading-loose lg:block relative",
+            toc:
+              "hidden text-sm font-light tracking-wide leading-loose lg:block relative",
             link: "flex flex-row items-center",
           },
           customizeTOCItem(item, heading) {
@@ -141,17 +143,20 @@ export function contribPackageRoute({
               heading.properties["data-kind"] &&
               heading.properties["data-name"]
             ) {
-              item.properties.className += " mb-1"
+              item.properties.className += " mb-1";
               const a = select("a", item);
               if (a) {
                 a.children = [
                   <Icon class="-ml-6" kind={heading.properties["data-kind"]} />,
-                  <span class="hover:underline hover:underline-offset-2">{heading.properties["data-name"]}</span>,
+                  <span class="hover:underline hover:underline-offset-2">
+                    {heading.properties["data-name"]}
+                  </span>,
                 ];
               }
             } else {
               const a = select("a", item);
-              a.properties.className = `hover:underline hover:underline-offset-2`
+              a.properties.className =
+                `hover:underline hover:underline-offset-2`;
             }
             return item;
           },
@@ -168,13 +173,11 @@ export function contribPackageRoute({
                   {yield* PackageHeader(pkg)}
                   <div class="prose max-w-full">
                     <div class="mb-5">
-                      {
-                        yield* PackageExports({
-                          packageName: pkg.packageName,
-                          docs,
-                          linkResolver,
-                        })
-                      }
+                      {yield* PackageExports({
+                        packageName: pkg.packageName,
+                        docs,
+                        linkResolver,
+                      })}
                     </div>
                     {content}
                   </div>
@@ -182,7 +185,10 @@ export function contribPackageRoute({
                 <aside class="xl:w-[260px] lg:col-[span_3/_-1] top-[120px] lg:sticky lg:max-h-screen flex flex-col box-border gap-y-4">
                   {yield* ScoreCard(pkg)}
                   <div>
-                    <div aria-hidden="true" class="hidden mb-1 lg:block text-sm font-bold">
+                    <div
+                      aria-hidden="true"
+                      class="hidden mb-1 lg:block text-sm font-bold"
+                    >
                       On this page
                     </div>
                     {toc}
@@ -211,7 +217,7 @@ export function contribPackageRoute({
 function* getEffectionDependency(page: DocPage, library: Repository) {
   let version, docs;
   let effection = page.dependencies.find((dep) =>
-    ["effection", "@effection/effection"].includes(dep.name),
+    ["effection", "@effection/effection"].includes(dep.name)
   );
   if (effection) {
     version = effection.version.replace("^", "");

--- a/routes/contrib-package-route.tsx
+++ b/routes/contrib-package-route.tsx
@@ -1,22 +1,23 @@
 import { type JSXElement, useParams } from "revolution";
-import { call, type Operation } from "effection";
+import { call } from "effection";
+import { shiftHeading } from "npm:hast-util-shift-heading@4.0.0";
+import rehypeAddClasses from "npm:rehype-add-classes@1.0.0";
+import type { Nodes } from "npm:@types/hast@3.0.4";
 
 import { PackageExports } from "../components/package/exports.tsx";
 import { PackageHeader } from "../components/package/header.tsx";
 import { ScoreCard } from "../components/score-card.tsx";
 import { DocPageContext } from "../context/doc-page.ts";
 import { DocPage } from "../hooks/use-deno-doc.tsx";
-import { ResolveLinkFunction, useMarkdown } from "../hooks/use-markdown.tsx";
+import { useMarkdown } from "../hooks/use-markdown.tsx";
 import { major, minor } from "../lib/semver.ts";
 import type { RoutePath, SitemapRoute } from "../plugins/sitemap.ts";
 import { Repository } from "../resources/repository.ts";
 import { useAppHtml } from "./app.html.tsx";
-import { shiftHeadings } from "../lib/shift-headings.ts";
-import { Package } from "../resources/package.ts";
-import { Type } from "../components/type/jsx.tsx";
-import { NO_DOCS_AVAILABLE } from "../components/type/markdown.tsx";
-import { SourceCodeIcon } from "../components/icons/source-code.tsx";
 import { createToc } from "../lib/toc.ts";
+import { ApiBody } from "../components/api/api-page.tsx";
+import { select } from "npm:hast-util-select@6.0.1";
+import { Icon } from "../components/type/icon.tsx";
 
 interface ContribPackageRouteParams {
   contrib: Repository;
@@ -97,16 +98,63 @@ export function contribPackageRoute({
           return symbol;
         };
 
+        const apiReference = [];
+
+        for (const page of docs["."]) {
+          apiReference.push(
+            yield* call(function* () {
+              yield* DocPageContext.set(page);
+              return yield* ApiBody({ page, linkResolver });
+            }),
+          );
+        }
+
+        apiReference.forEach((section) => shiftHeading(section, 1));
+
         const content = (
           <>
             {yield* useMarkdown(yield* pkg.readme(), { linkResolver })}
-            <h2 class="mb-0">API Reference</h2>
-            {yield* API({ pkg, linkResolver, library })}
+            <h2 id="api-reference">API Reference</h2>
+            <>{apiReference}</>
           </>
         );
 
         const toc = createToc(content, {
-          headings: ["h2", "h3"]
+          headings: ["h2", "h3"],
+          cssClasses: {
+            toc: "hidden text-sm font-light tracking-wide leading-loose lg:block relative",
+            link: "flex flex-row items-center",
+          },
+          customizeTOCItem(item, heading) {
+            heading.properties.class = [
+              heading.properties.class,
+              `group scroll-mt-[100px]`,
+            ]
+              .filter(Boolean)
+              .join("");
+
+            const ol = select("ol.toc-level-2, ol.toc-level-3", item as Nodes);
+            if (ol) {
+              ol.properties.className = `${ol.properties.className} ml-6`;
+            }
+            if (
+              heading.properties["data-kind"] &&
+              heading.properties["data-name"]
+            ) {
+              item.properties.className += " mb-1"
+              const a = select("a", item);
+              if (a) {
+                a.children = [
+                  <Icon class="-ml-6" kind={heading.properties["data-kind"]} />,
+                  <span class="hover:underline hover:underline-offset-2">{heading.properties["data-name"]}</span>,
+                ];
+              }
+            } else {
+              const a = select("a", item);
+              a.properties.className = `hover:underline hover:underline-offset-2`
+            }
+            return item;
+          },
         });
 
         return (
@@ -134,7 +182,9 @@ export function contribPackageRoute({
                 <aside class="xl:w-[260px] lg:col-[span_3/_-1] top-[120px] lg:sticky lg:max-h-screen flex flex-col box-border gap-y-4">
                   {yield* ScoreCard(pkg)}
                   <div>
-                    <div aria-hidden="true" class="mb-1 text-sm font-bold">On this page</div>
+                    <div aria-hidden="true" class="hidden mb-1 md:block text-sm font-bold">
+                      On this page
+                    </div>
                     {toc}
                   </div>
                 </aside>
@@ -156,69 +206,6 @@ export function contribPackageRoute({
       }
     },
   };
-}
-
-interface APIOptions {
-  pkg: Package;
-  linkResolver: ResolveLinkFunction;
-  library: Repository;
-}
-
-export function* API({
-  pkg,
-  linkResolver,
-  library,
-}: APIOptions): Operation<JSXElement> {
-  const elements: JSXElement[] = [];
-  const docs = yield* pkg.docs();
-
-  for (const exportName of Object.keys(docs)) {
-    const pages = docs[exportName];
-    const withoutImports = pages.flatMap((page) =>
-      page.kind === "import" ? [] : [page],
-    );
-    for (const page of withoutImports) {
-      const effection = yield* getEffectionDependency(page, library);
-      for (const section of page.sections) {
-        elements.push(
-          <section
-            id={section.id}
-            data-series={
-              effection.version ? `v${major(effection.version)}` : ""
-            }
-            class="flex flex-col border-b-2 pb-5"
-          >
-            <div class="flex group">
-              <h3 class="grow">{yield* Type({ node: section.node })}</h3>
-              <a
-                class="mt-8 opacity-0 before:content-['View_code'] group-hover:opacity-100 before:flex before:text-xs before:mr-1 hover:bg-gray-100 p-2 flex-none flex rounded no-underline items-center h-8"
-                href={`${section.node.location.filename}#L${section.node.location.line}`}
-              >
-                <SourceCodeIcon />
-              </a>
-            </div>
-            <div class="[&>h3:first-child]:mt-0 [&>hr]:my-5 [&>h5]:font-semibold">
-              {
-                yield* call(function* () {
-                  yield* DocPageContext.set(page);
-                  return yield* useMarkdown(
-                    section.markdown || NO_DOCS_AVAILABLE,
-                    {
-                      remarkPlugins: [[shiftHeadings, 1]],
-                      linkResolver,
-                      slugPrefix: section.id,
-                    },
-                  );
-                })
-              }
-            </div>
-          </section>,
-        );
-      }
-    }
-  }
-
-  return <>{elements}</>;
 }
 
 function* getEffectionDependency(page: DocPage, library: Repository) {

--- a/routes/docs-route.tsx
+++ b/routes/docs-route.tsx
@@ -53,18 +53,20 @@ export function docsRoute({
         for (const item of topic.items) {
           items.push(
             <li class="mt-1">
-              {doc.id !== item.id ? (
-                <a
-                  class="rounded px-4 block w-full py-2 hover:bg-gray-100"
-                  href={yield* createSibling(item.id)}
-                >
-                  {item.title}
-                </a>
-              ) : (
-                <a class="rounded px-4 block w-full py-2 bg-gray-100 cursor-default">
-                  {item.title}
-                </a>
-              )}
+              {doc.id !== item.id
+                ? (
+                  <a
+                    class="rounded px-4 block w-full py-2 hover:bg-gray-100"
+                    href={yield* createSibling(item.id)}
+                  >
+                    {item.title}
+                  </a>
+                )
+                : (
+                  <a class="rounded px-4 block w-full py-2 bg-gray-100 cursor-default">
+                    {item.title}
+                  </a>
+                )}
             </li>,
           );
         }
@@ -133,32 +135,32 @@ function* NextPrevLinks({
   let { next, prev } = doc;
   return (
     <menu class="grid grid-cols-2 my-10 gap-x-2 xl:gap-x-20 2xl:gap-x-40 text-lg">
-      {prev ? (
-        <li class="col-start-1 text-left font-light border-1 rounded-lg p-4">
-          Previous
-          <a
-            class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 before:content-['«&nbsp;'] before:font-normal"
-            href={yield* createSibling(prev.id)}
-          >
-            {prev.title}
-          </a>
-        </li>
-      ) : (
-        <li />
-      )}
-      {next ? (
-        <li class="col-start-2 text-right font-light border-1 rounded-lg p-4">
-          Next
-          <a
-            class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 after:content-['&nbsp;»'] after:font-normal"
-            href={yield* createSibling(next.id)}
-          >
-            {next.title}
-          </a>
-        </li>
-      ) : (
-        <li />
-      )}
+      {prev
+        ? (
+          <li class="col-start-1 text-left font-light border-1 rounded-lg p-4">
+            Previous
+            <a
+              class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 before:content-['«&nbsp;'] before:font-normal"
+              href={yield* createSibling(prev.id)}
+            >
+              {prev.title}
+            </a>
+          </li>
+        )
+        : <li />}
+      {next
+        ? (
+          <li class="col-start-2 text-right font-light border-1 rounded-lg p-4">
+            Next
+            <a
+              class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 after:content-['&nbsp;»'] after:font-normal"
+              href={yield* createSibling(next.id)}
+            >
+              {next.title}
+            </a>
+          </li>
+        )
+        : <li />}
     </menu>
   );
 }

--- a/routes/docs-route.tsx
+++ b/routes/docs-route.tsx
@@ -53,20 +53,18 @@ export function docsRoute({
         for (const item of topic.items) {
           items.push(
             <li class="mt-1">
-              {doc.id !== item.id
-                ? (
-                  <a
-                    class="rounded px-4 block w-full py-2 hover:bg-gray-100"
-                    href={yield* createSibling(item.id)}
-                  >
-                    {item.title}
-                  </a>
-                )
-                : (
-                  <a class="rounded px-4 block w-full py-2 bg-gray-100 cursor-default">
-                    {item.title}
-                  </a>
-                )}
+              {doc.id !== item.id ? (
+                <a
+                  class="rounded px-4 block w-full py-2 hover:bg-gray-100"
+                  href={yield* createSibling(item.id)}
+                >
+                  {item.title}
+                </a>
+              ) : (
+                <a class="rounded px-4 block w-full py-2 bg-gray-100 cursor-default">
+                  {item.title}
+                </a>
+              )}
             </li>,
           );
         }
@@ -117,7 +115,7 @@ export function docsRoute({
             </article>
             <aside class="min-h-0 overflow-auto sticky h-fit hidden md:block top-[120px]">
               <h3>On this page</h3>
-              <>{doc.toc}</>
+              <div class="w-[200px]">{doc.toc}</div>
             </aside>
           </section>
         </AppHtml>
@@ -135,32 +133,32 @@ function* NextPrevLinks({
   let { next, prev } = doc;
   return (
     <menu class="grid grid-cols-2 my-10 gap-x-2 xl:gap-x-20 2xl:gap-x-40 text-lg">
-      {prev
-        ? (
-          <li class="col-start-1 text-left font-light border-1 rounded-lg p-4">
-            Previous
-            <a
-              class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 before:content-['«&nbsp;'] before:font-normal"
-              href={yield* createSibling(prev.id)}
-            >
-              {prev.title}
-            </a>
-          </li>
-        )
-        : <li />}
-      {next
-        ? (
-          <li class="col-start-2 text-right font-light border-1 rounded-lg p-4">
-            Next
-            <a
-              class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 after:content-['&nbsp;»'] after:font-normal"
-              href={yield* createSibling(next.id)}
-            >
-              {next.title}
-            </a>
-          </li>
-        )
-        : <li />}
+      {prev ? (
+        <li class="col-start-1 text-left font-light border-1 rounded-lg p-4">
+          Previous
+          <a
+            class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 before:content-['«&nbsp;'] before:font-normal"
+            href={yield* createSibling(prev.id)}
+          >
+            {prev.title}
+          </a>
+        </li>
+      ) : (
+        <li />
+      )}
+      {next ? (
+        <li class="col-start-2 text-right font-light border-1 rounded-lg p-4">
+          Next
+          <a
+            class="py-2 block text-xl font-bold text-blue-primary no-underline tracking-wide leading-5 after:content-['&nbsp;»'] after:font-normal"
+            href={yield* createSibling(next.id)}
+          >
+            {next.title}
+          </a>
+        </li>
+      ) : (
+        <li />
+      )}
     </menu>
   );
 }


### PR DESCRIPTION
## Motivation

I wanted to add TOC to contrib pages and ended up replacing the API reference section from HTML with Markdown. The Markdown version is cleaner. 

<img width="1592" alt="image" src="https://github.com/user-attachments/assets/510896d8-0300-44e7-b245-29151bcf150d" />

<img width="1175" alt="image" src="https://github.com/user-attachments/assets/d705b7ac-5aaf-4c7c-acb1-271f30f11aa6" />

<img width="966" alt="image" src="https://github.com/user-attachments/assets/6e558f37-aa77-4678-9544-11c254959009" />


## Approach

1. Made repository response in jsr client nullable to support when repository is not specified.
2. replaced API Reference with markdown
3. cleaned up the CSS and responsible of the sidebar