### PR TITLE
Strip out hostname from redirect

### DIFF
--- a/routes/redirect.tsx
+++ b/routes/redirect.tsx
@@ -13,7 +13,7 @@ export function* softRedirect(req: Request, to: string) {
     title: `Redirect to ${to} | Effection`,
     description: `Redirect ${to}`,
     hasLeftSidebar: true,
-    head: <meta http-equiv="refresh" content={`0; url=${url}`} />,
+    head: <meta http-equiv="refresh" content={`0; url=${url.toString().replace(url.origin, "")}`} />,
   });
 
   return (

--- a/routes/redirect.tsx
+++ b/routes/redirect.tsx
@@ -13,7 +13,12 @@ export function* softRedirect(req: Request, to: string) {
     title: `Redirect to ${to} | Effection`,
     description: `Redirect ${to}`,
     hasLeftSidebar: true,
-    head: <meta http-equiv="refresh" content={`0; url=${url.toString().replace(url.origin, "")}`} />,
+    head: (
+      <meta
+        http-equiv="refresh"
+        content={`0; url=${url.toString().replace(url.origin, "")}`}
+      />
+    ),
   });
 
   return (


### PR DESCRIPTION
Closes #20 

## Motivation

The site is redirecting to 127.0.0.1 which is the host where the site was built. 

## Approach

We need to remove the host.