### PR TITLE
Added support for ^major semver selector

### DIFF
--- a/hooks/use-deno-doc.tsx
+++ b/hooks/use-deno-doc.tsx
@@ -58,6 +58,7 @@ export function* useDocPages(specifier: string): Operation<DocsPages> {
     new URL("./deno.json", specifier).toString(),
     loader,
   );
+
   const resolve = imports
     ? (specifier: string, referrer: string) => {
       let resolved: string = specifier;

--- a/resources/jsr-client.ts
+++ b/resources/jsr-client.ts
@@ -39,7 +39,7 @@ const PackageDetails = z.object({
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
   }).nullable(),
-  score: z.number().min(0).max(100),
+  score: z.number().min(0).max(100).nullable(),
 });
 
 export type PackageScoreResult = z.infer<typeof PackageScore>;

--- a/resources/repository.ts
+++ b/resources/repository.ts
@@ -53,6 +53,13 @@ export interface Repository {
   ): Operation<{ name: string } | undefined>;
 
   /**
+   * Get a list of versions from tags matching a major version
+   * @param major 
+   * return list of tags
+   */
+  getSemverTags(major: string): Operation<string[] | undefined>
+
+  /**
    * Get contents of a repository
    *
    * @param params.path path to the content
@@ -128,6 +135,13 @@ export function loadRepository(
         );
 
         return result.repository.refs.nodes;
+      },
+      *getSemverTags(major: string) {
+        const tags = yield* this.tags(`tags/effection-v${major}*`);
+
+        return rsort(
+          tags.map((tag) => tag.name).map(extractVersion),
+        )
       },
       *getLatestSemverTag(glob: string) {
         const tags = yield* this.tags(glob);


### PR DESCRIPTION
## Motivation

`ref` package is not displaying because the site was not matching on `effection@^3` dependency correctly.

## Approach

Find matching version for ^major

