### PR TITLE
Escape the output to prevent markdown compiler from crashing

### DIFF
--- a/components/search-input.tsx
+++ b/components/search-input.tsx
@@ -3,11 +3,13 @@ import { SearchIcon } from "./icons/search.tsx";
 
 const searchInput = css`
   input {
-    @apply relative block h-full w-full bg-slate-100 rounded-full text-slate-800 transition-all text-lg pl-3;
+    @apply relative block h-full w-full bg-slate-100 rounded-full text-slate-800
+      transition-all text-lg pl-3;
   }
 
   input.focused {
-    @apply outline-none bg-white border-slate-500 ring-slate-500 ring-2 pl-4 w-[220px] -ml-[130px] z-1;
+    @apply outline-none bg-white border-slate-500 ring-slate-500 ring-2 pl-4
+      w-[220px] -ml-[130px] z-1;
   }
 
   input::-webkit-search-cancel-button {

--- a/components/type/markdown.tsx
+++ b/components/type/markdown.tsx
@@ -271,7 +271,7 @@ export function TypeDef(typeDef: TsTypeDef): string {
       const tparams = typeDef.fnOrConstructor.typeParams
         .map(TypeParam)
         .join(", ");
-      return `(${params})${tparams.length > 0 ? `<${tparams}>` : ""} => ${
+      return `${tparams.length > 0 ? `&lt;${tparams}&gt;` : ""}(${params}) => ${
         TypeDef(
           typeDef.fnOrConstructor.tsType,
         )

--- a/resources/repository.ts
+++ b/resources/repository.ts
@@ -54,10 +54,10 @@ export interface Repository {
 
   /**
    * Get a list of versions from tags matching a major version
-   * @param major 
+   * @param major
    * return list of tags
    */
-  getSemverTags(major: string): Operation<string[] | undefined>
+  getSemverTags(major: string): Operation<string[] | undefined>;
 
   /**
    * Get contents of a repository
@@ -141,7 +141,7 @@ export function loadRepository(
 
         return rsort(
           tags.map((tag) => tag.name).map(extractVersion),
-        )
+        );
       },
       *getLatestSemverTag(glob: string) {
         const tags = yield* this.tags(glob);

--- a/routes/x-package-route.tsx
+++ b/routes/x-package-route.tsx
@@ -256,7 +256,10 @@ export function xPackageRoute({
   };
 }
 
-function* getEffectionDependency(page: DocPage, library: Repository): Operation<{ version: string, docs: DocsPages } | undefined> {
+function* getEffectionDependency(
+  page: DocPage,
+  library: Repository,
+): Operation<{ version: string; docs: DocsPages } | undefined> {
   console.log(`Searching for effection dependency in page ${page.name}`);
   let effection = page.dependencies.find((dep) =>
     ["effection", "@effection/effection"].includes(dep.name)
@@ -266,15 +269,15 @@ function* getEffectionDependency(page: DocPage, library: Repository): Operation<
     if (version) {
       const versions = yield* library.getSemverTags(version.major.toString());
       if (versions) {
-        let latest = versions.find(v => satisfies(v, effection.version));
+        let latest = versions.find((v) => satisfies(v, effection.version));
         if (latest) {
           const ref = yield* library.loadRef(`tags/effection-v${latest}`);
           const pkg = yield* ref.loadRootPackage();
           if (pkg) {
             return {
               version: latest,
-              docs: yield* pkg.docs()
-            }
+              docs: yield* pkg.docs(),
+            };
           } else {
             console.log(`Failed to load root package for version ${latest}`);
           }


### PR DESCRIPTION
## Motivation

<img width="964" alt="image" src="https://github.com/user-attachments/assets/aacf72b2-b017-4bd9-8931-a545dad1590e" />


## Approach

Added escape to `<T>`

## Screenshots

<img width="964" alt="image" src="https://github.com/user-attachments/assets/76b2efbc-b874-492a-b5bd-00e8e55948ed" />
