### PR TITLE
⬆️ upgrade staticalize

### DIFF
--- a/.github/workflows/staticalize.yaml
+++ b/.github/workflows/staticalize.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Download Staticalize
         run: |
-          wget https://github.com/thefrontside/staticalize/releases/download/v0.2.1/staticalize-linux.tar.gz \
+          wget https://github.com/thefrontside/staticalize/releases/download/v0.2.2/staticalize-linux.tar.gz \
             -O /tmp/staticalize-linux.tar.gz
           tar -xzf /tmp/staticalize-linux.tar.gz -C /usr/local/bin
           chmod +x /usr/local/bin/staticalize-linux


### PR DESCRIPTION
## Motivation

The previous staticalize version upgrade was borked because staticalize v0.2.1 was mis-tagged and did not actually include any fixes.

## Approach

This updates the staticalize version to v0.2.2


### TODOs and Open Questions

I've tested locally using the command:

```
staticalize --site http://localhost:8000 --output=built --base=http://effection-www.deno.dev
```

And it properly substitutes all absolute urls in the header. However, the server uses a different dev server, `http://127.0.0.1` which may cause problems.
