### PR TITLE
Use docs from main

### DIFF
--- a/routes/api-index-route.tsx
+++ b/routes/api-index-route.tsx
@@ -93,7 +93,7 @@ export function apiIndexRoute({
                 })}
               </ul>
               <h3>Previous releases</h3>
-              <ul>
+              <ul class="pl-0">
                 {(yield* fetchMinorVersions({
                   repository: library,
                   pattern: "effection-v3",
@@ -121,10 +121,10 @@ export function apiIndexRoute({
               </p>
               <div class="flex flex-row items-center mt-5 mb-3 space-x-2">
                 <h3 class="my-0">Latest release: {v4version}</h3>
-                <div class="h-fit">
+                <div class="mt-5">
                   (
                   <a
-                    class="text-sm text-blue-700 dark:text-blue-400"
+                    class="text-blue-700 dark:text-blue-400"
                     href="/guides/v4/"
                   >
                     Guides

--- a/routes/guides-route.tsx
+++ b/routes/guides-route.tsx
@@ -75,7 +75,7 @@ export function guidesRoute({
         series: string | undefined;
       }>();
 
-      const ref = yield* getSeriesRef({ repository, series });
+      const ref = yield* repository.loadRef(`heads/${series}`);
       const pages = yield* guides({ ref });
 
       if (!id) {
@@ -136,6 +136,8 @@ export function guidesRoute({
         );
       }
 
+      const latest = yield* getSeriesRef({ repository, series });
+
       return (
         <AppHtml search={search}>
           <section class="min-h-0 mx-auto w-full justify-items-normal md:grid md:grid-cols-[225px_auto] lg:grid-cols-[225px_auto_200px] md:gap-4">
@@ -164,7 +166,7 @@ export function guidesRoute({
             <aside class="min-h-0 overflow-auto hidden md:block top-[120px] sticky h-fit bg-white dark:bg-gray-900 dark:text-gray-200">
               <div class="text-xl flex flex-row items-baseline space-x-2 mb-3">
                 <span class="font-bold">Guides</span>
-                <a href={ref.url} class="text-base">
+                <a href={latest.url} class="text-base">
                   {series}{" "}
                   <IconExternal
                     class="inline-block align-baseline"


### PR DESCRIPTION
## Motivation

Docs were not updating because they were being read from latest release for each mainline:
* v3 -> 3.6.0
* v4 -> 4.0.0-beta.2

But we're not updating those branches until releases so the docs were not updating in the mean time. 

## Approach

Do not look up the latest and just use the head instead.