### PR TITLE
📝 docs: use #effection channel discord link

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -77,7 +77,7 @@ export function* Header(props?: HeaderProps) {
             <li class="hidden md:flex">
               <a
                 class="flex flex-row items-center space-x-1 hover:text-pink-secondary dark:hover:text-blue-secondary transition-colors duration-200"
-                href="https://discord.gg/r6AvtnU"
+                href="https://discord.gg/Ug5nWH8"
               >
                 <IconDiscord />
                 <span>Discord</span>


### PR DESCRIPTION
## Motivation

Our current invite in the header was recycle from BigTest and by default, after they have completed the onboarding, it drops them into the #bigtest channel. That's not what we want for someone who comes into the Frontside Server from the Effection website.

## Approach

This adds a new invite link, originating from Jack, to the header that is associated with the #effection channel in discord.